### PR TITLE
unuse singleton for CrowiClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,76 +20,75 @@ Or install it yourself as:
 
 ## Usage
 
-At first, you need to create setting file ```config/settings.yml``` in your application directory.
-And set token key of crowi API, and URL of crowi (ex. http://localhost:3000) in ```settings.yml```.
+Export these environments.
 
-```YAML
-# Example of config/settings.yml. YOU NEED TO REPLACE token!!!
-token: xEKAueUZDrQlr30iFZr96ti3GUd8sqP/pTkS3DGrwcc=
-url: http://localhost:3000/
 ```
-
-Then, you can use crowi client with ```require 'crowi-client'```.
+export CROWI_ACCESS_TOKEN=0123456789abcdef0123456789abcdef0123456789ab
+export CROWI_URL=http://localhost:3000/
+```
 
 ```ruby
 require 'crowi-client'
-puts CrowiClient.instance.page_exist?( path_exp: '/' )
-puts CrowiClient.instance.attachment_exist?( path_exp: '/', attachment_name: 'LICENSE.txt' )
+
+crowi_client = CrowiClient.new(crowi_url: ENV['CROWI_URL'], access_token: ENV['CROWI_ACCESS_TOKEN'])
+
+puts crowi_client.page_exist?( path_exp: '/' )
+puts crowi_client.attachment_exist?( path_exp: '/', attachment_name: 'LICENSE.txt' )
 ```
 
 ## Examples
 
 ```ruby
 # get page's ID
-puts CrowiClient.instance.page_id( path_exp: '/' )
+puts crowi_client.page_id( path_exp: '/' )
 ```
 
 ```ruby
 # Check existence of page by page path (you can use regular expression)
-CrowiClient.instance.page_exist?( path_exp: '/' )
+crowi_client.page_exist?( path_exp: '/' )
 ```
 
 ```ruby
 # Check existence of attachment by file name of attachment
-CrowiClient.instance.attachment_exist?( path_exp: '/', attachment_name: 'LICENSE.txt' )
+crowi_client.attachment_exist?( path_exp: '/', attachment_name: 'LICENSE.txt' )
 ```
 
 ```ruby
 # get attachment's ID
-puts CrowiClient.instance.attachment_id( path_exp: '/', attachment_name: 'LICENSE.txt' )
+puts crowi_client.attachment_id( path_exp: '/', attachment_name: 'LICENSE.txt' )
 ```
 
 ```ruby
 # get attachment (return data is object of CrowiAttachment)
-puts CrowiClient.instance.attachment( path_exp: '/', attachment_name: 'LICENSE.txt' )
+puts crowi_client.attachment( path_exp: '/', attachment_name: 'LICENSE.txt' )
 ```
 
 ```ruby
 # pages list
 req = CPApiRequestPagesList.new path_exp: '/'
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ```ruby
 # pages get - path_exp
 req = CPApiRequestPagesList.new path_exp: '/'
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ```ruby
 # pages get - page_id
-req = CPApiRequestPagesGet.new page_id: CrowiClient.instance.page_id(path: '/')
-puts CrowiClient.instance.request(req)
+req = CPApiRequestPagesGet.new page_id: crowi_client.page_id(path_exp: '/')
+puts crowi_client.request(req)
 ```
 
 ```ruby
 # pages get - revision_id
 reqtmp = CPApiRequestPagesList.new path_exp: '/'
-ret = CrowiClient.instance.request(reqtmp)
+ret = crowi_client.request(reqtmp)
 path = ret.data[0].path
 revision_id = ret.data[0].revision._id
 req = CPApiRequestPagesGet.new path: path, revision_id: revision_id
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ```ruby
@@ -98,7 +97,7 @@ test_page_path = '/tmp/crowi-client test page'
 body = "# crowi-client\n"
 req = CPApiRequestPagesCreate.new path: test_page_path,
         body: body
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ```ruby
@@ -106,74 +105,74 @@ puts CrowiClient.instance.request(req)
 test_page_path = '/tmp/crowi-client test page'
 test_cases = [nil, CrowiPage::GRANT_PUBLIC, CrowiPage::GRANT_RESTRICTED,
               CrowiPage::GRANT_SPECIFIED, CrowiPage::GRANT_OWNER]
-page_id = CrowiClient.instance.page_id(path: test_page_path)
+page_id = crowi_client.page_id(path_exp: test_page_path)
 
 body = "# crowi-client\n"
 test_cases.each do |grant|
   body = body + grant.to_s
   req = CPApiRequestPagesUpdate.new page_id: page_id,
           body: body, grant: grant
-  puts CrowiClient.instance.request(req)
+  puts crowi_client.request(req)
 end
 ```
 
 ```ruby
 # pages seen
-page_id = CrowiClient.instance.page_id(path: '/')
+page_id = crowi_client.page_id(path_exp: '/')
 req = CPApiRequestPagesSeen.new page_id: page_id
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ```ruby
 # likes add
 test_page_path = '/tmp/crowi-client test page'
-page_id = CrowiClient.instance.page_id(path: test_page_path)
+page_id = crowi_client.page_id(path_exp: test_page_path)
 req = CPApiRequestLikesAdd.new page_id: page_id
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ```ruby
 # likes remove
 test_page_path = '/tmp/crowi-client test page'
-page_id = CrowiClient.instance.page_id(path: test_page_path)
+page_id = crowi_client.page_id(path_exp: test_page_path)
 req = CPApiRequestLikesRemove.new page_id: page_id
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ```ruby
 # update post
 test_page_path = '/tmp/crowi-client test page'
 req = CPApiRequestPagesUpdatePost.new path: test_page_path
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 
 ```ruby
 # attachments list
 test_page_path = '/tmp/crowi-client test page'
-page_id = CrowiClient.instance.page_id(path: test_page_path)
+page_id = crowi_client.page_id(path_exp: test_page_path)
 req = CPApiRequestAttachmentsList.new page_id: page_id
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ```ruby
 # attachments add
 test_page_path = '/tmp/crowi-client test page'
-page_id = CrowiClient.instance.page_id(path: test_page_path)
+page_id = crowi_client.page_id(path_exp: test_page_path)
 req = CPApiRequestAttachmentsAdd.new page_id: page_id,
                                      file: File.new('LICENSE.txt')
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ```ruby
 # attachments remove
 test_page_path = '/tmp/crowi-client test page'
-page_id = CrowiClient.instance.page_id(path: test_page_path)
+page_id = crowi_client.page_id(path_exp: test_page_path)
 reqtmp = CPApiRequestAttachmentsList.new page_id: page_id
-ret = CrowiClient.instance.request(reqtmp)
+ret = crowi_client.request(reqtmp)
 attachment_id = ret.data[0]._id
 req = CPApiRequestAttachmentsRemove.new attachment_id: attachment_id
-puts CrowiClient.instance.request(req)
+puts crowi_client.request(req)
 ```
 
 ## Development

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,2 +1,0 @@
-url:   http://localhost:3000/
-token: 9MFP98pB81xFI/4EuBzoYgIGZvno5QT3kcgSB3oEuHE=

--- a/lib/crowi/client/client.rb
+++ b/lib/crowi/client/client.rb
@@ -1,28 +1,28 @@
-require 'singleton'
 require 'rest-client'
 require 'json'
 require 'yaml'
-require "easy_settings"
 
 require 'crowi/client/apireq/api_request_pages'
 require 'crowi/client/apireq/api_request_attachments'
 
 # Crowi のクライアントクラス
 class CrowiClient
-  include Singleton
 
-  # コンストラクタ（シングルトン）
-  def initialize
-    raise ArgumentError, 'Config url is required.'   unless EasySettings['url']
-    raise ArgumentError, 'Config token is required.' unless EasySettings['token']
-    @cp_entry_point = URI.join(EasySettings['url'], '/_api/').to_s
+  # コンストラクタ
+  def initialize(crowi_url: '', access_token: '')
+    raise ArgumentError, 'Config `crowi_url` is required.'    if crowi_url.empty?
+    raise ArgumentError, 'Config `access_token` is required.' if access_token.empty?
+
+    @crowi_url = crowi_url
+    @access_toke = access_token
+    @cp_entry_point = URI.join(crowi_url, '/_api/').to_s
   end
 
   # APIリクエストを送信する
   # @param [ApiRequestBase] req APIリクエスト
   # @return [String] APIリクエストの応答（JSON形式）
   def request(req)
-    req.param[:access_token] = EasySettings['token'] 
+    req.param[:access_token] = @access_toke
     return req.execute URI.join(@cp_entry_point, req.entry_point).to_s
   end
 

--- a/spec/crowi/client_spec.rb
+++ b/spec/crowi/client_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Crowi::Client do
   let(:test_page_path)                   { '/tmp/crowi-client test page'  }
   let(:test_page_path_extend_for_create) { '/tmp/crowi-client(test page)' }
   let(:test_page_path_extend_for_get)    { '/tmp/crowi-client\(test page\)' }
+  let(:crowi_client)                     { CrowiClient.new(crowi_url: ENV['CROWI_URL'],
+                                                           access_token: ENV['CROWI_ACCESS_TOKEN']) }
 
   describe '# CrowiClient\'s basic attributes and methods :' do
     # Test for VERSION
@@ -19,7 +21,7 @@ RSpec.describe Crowi::Client do
     # Test for function to get page list
     it "get list of page" do
       req = CPApiRequestPagesList.new path_exp: '/'
-      expect(CrowiClient.instance.request(req).ok).to eq true
+      expect(crowi_client.request(req).ok).to eq true
     end
   
     # Test for function to get page
@@ -27,18 +29,18 @@ RSpec.describe Crowi::Client do
       aggregate_failures 'some pattern to get page' do
         # get page specified path
         req = CPApiRequestPagesGet.new path: '/'
-        expect(CrowiClient.instance.request(req).ok).to eq true
+        expect(crowi_client.request(req).ok).to eq true
   
         # get page specified page_id
-        req = CPApiRequestPagesGet.new page_id: CrowiClient.instance.page_id(path_exp: '/')
-        expect(CrowiClient.instance.request(req).ok).to eq true
+        req = CPApiRequestPagesGet.new page_id: crowi_client.page_id(path_exp: '/')
+        expect(crowi_client.request(req).ok).to eq true
   
         # get page specified path and revision_id
         reqtmp = CPApiRequestPagesList.new path_exp: '/'
-        ret = CrowiClient.instance.request(reqtmp)
+        ret = crowi_client.request(reqtmp)
         page = ret&.data&.find{ |page| page.path == '/' }
         req = CPApiRequestPagesGet.new path: page.path, revision_id: page.revision._id
-        expect(CrowiClient.instance.request(req).ok).to eq true
+        expect(crowi_client.request(req).ok).to eq true
       end
     end
   
@@ -47,49 +49,49 @@ RSpec.describe Crowi::Client do
       body = "# crowi-client\n"
       req = CPApiRequestPagesCreate.new path: test_page_path,
               body: body
-      expect(CrowiClient.instance.request(req).ok).to eq true
+      expect(crowi_client.request(req).ok).to eq true
     end
 
     # Test for function to update page
     it "update page" do
       test_cases = [nil, CrowiPage::GRANT_PUBLIC, CrowiPage::GRANT_RESTRICTED,
                     CrowiPage::GRANT_SPECIFIED, CrowiPage::GRANT_OWNER]
-      page_id = CrowiClient.instance.page_id(path_exp: test_page_path)
+      page_id = crowi_client.page_id(path_exp: test_page_path)
   
       body = "# crowi-client\n"
       test_cases.each do |grant| 
         body = body + grant.to_s
         req = CPApiRequestPagesUpdate.new page_id: page_id,
                 body: body, grant: grant
-        expect(CrowiClient.instance.request(req).ok).to eq true
+        expect(crowi_client.request(req).ok).to eq true
       end
     end
   
     # Test for function to get the page list, which is seen
     it "get seen pages" do
-      page_id = CrowiClient.instance.page_id(path_exp: '/')
+      page_id = crowi_client.page_id(path_exp: '/')
       req = CPApiRequestPagesSeen.new page_id: page_id
-      expect(CrowiClient.instance.request(req).ok).to eq true
+      expect(crowi_client.request(req).ok).to eq true
     end
   
     # Test for function to react LIKE
     it "add LIKE reaction" do
-      page_id = CrowiClient.instance.page_id(path_exp: test_page_path)
+      page_id = crowi_client.page_id(path_exp: test_page_path)
       req = CPApiRequestLikesAdd.new page_id: page_id
-      expect(CrowiClient.instance.request(req).ok).to eq true
+      expect(crowi_client.request(req).ok).to eq true
     end
   
     # Test for function to cancel LIKE reaction
     it "remove LIKE reaction" do
-      page_id = CrowiClient.instance.page_id(path_exp: test_page_path)
+      page_id = crowi_client.page_id(path_exp: test_page_path)
       req = CPApiRequestLikesRemove.new page_id: page_id
-      expect(CrowiClient.instance.request(req).ok).to eq true
+      expect(crowi_client.request(req).ok).to eq true
     end
   
     # Test for function to set update post
     it "update post" do
       req = CPApiRequestPagesUpdatePost.new path: test_page_path
-      expect(CrowiClient.instance.request(req).ok).to eq true
+      expect(crowi_client.request(req).ok).to eq true
     end
 
     # Test for function to check page existence
@@ -97,8 +99,8 @@ RSpec.describe Crowi::Client do
     #       (ex. path '/' is not promises existence, and path '/tmp/#####FAKE_PATH#####' is also)
     it "check page existence" do
       aggregate_failures 'exist page, and not exist page' do
-        expect(CrowiClient.instance.page_exist?( path_exp: '/' )).to eql(true)
-        expect(CrowiClient.instance.page_exist?( path_exp: '/tmp/#####FAKE_PAGE#####' )).to eql(false)
+        expect(crowi_client.page_exist?( path_exp: '/' )).to eql(true)
+        expect(crowi_client.page_exist?( path_exp: '/tmp/#####FAKE_PAGE#####' )).to eql(false)
       end
     end
   end
@@ -106,38 +108,38 @@ RSpec.describe Crowi::Client do
   describe '# API related Crowi attachments :' do
     # Test for function to get attachment list
     it "get attachments list" do
-      page_id = CrowiClient.instance.page_id(path_exp: test_page_path)
+      page_id = crowi_client.page_id(path_exp: test_page_path)
       req = CPApiRequestAttachmentsList.new page_id: page_id
-      expect(CrowiClient.instance.request(req).ok).to eq true
+      expect(crowi_client.request(req).ok).to eq true
     end
  
     # Test for function to add attachment
     it "add attachment" do
-      page_id = CrowiClient.instance.page_id(path_exp: test_page_path)
+      page_id = crowi_client.page_id(path_exp: test_page_path)
       req = CPApiRequestAttachmentsAdd.new page_id: page_id,
                                            file: File.new('LICENSE.txt')
-      expect(CrowiClient.instance.request(req).ok).to eq true
+      expect(crowi_client.request(req).ok).to eq true
     end
   
     # Test for function to check attachment existence
     it "check attachment existence" do
-      expect(CrowiClient.instance.attachment_exist?(path_exp: test_page_path, attachment_name: 'LICENSE.txt')).to eql(true)
+      expect(crowi_client.attachment_exist?(path_exp: test_page_path, attachment_name: 'LICENSE.txt')).to eql(true)
     end
  
     # Test for function to get attachment info
     it "get attachment info" do
-      a = CrowiClient.instance.attachment(path_exp: test_page_path, attachment_name: 'LICENSE.txt')
+      a = crowi_client.attachment(path_exp: test_page_path, attachment_name: 'LICENSE.txt')
       expect(a.originalName).to eq 'LICENSE.txt'
     end
 
     # Test for function to remove attachment file
     it "remove attachment" do
-      page_id = CrowiClient.instance.page_id(path_exp: test_page_path)
+      page_id = crowi_client.page_id(path_exp: test_page_path)
       reqtmp = CPApiRequestAttachmentsList.new page_id: page_id
-      ret = CrowiClient.instance.request(reqtmp)
+      ret = crowi_client.request(reqtmp)
       attachment_id = ret.data[0]._id
       req = CPApiRequestAttachmentsRemove.new attachment_id: attachment_id
-      expect(CrowiClient.instance.request(req).ok).to eq true
+      expect(crowi_client.request(req).ok).to eq true
     end
   end
 
@@ -146,7 +148,7 @@ RSpec.describe Crowi::Client do
     before do
       body = "# crowi-client\n"
       req = CPApiRequestPagesCreate.new path: test_page_path_extend_for_create, body: body
-      CrowiClient.instance.request(req)
+      crowi_client.request(req)
     end
 
     # Test for function to get page
@@ -155,8 +157,8 @@ RSpec.describe Crowi::Client do
     it "execute page_id" do
       # get page_id 
       aggregate_failures 'some pattern to get page' do
-        expect(CrowiClient.instance.page_id(path_exp: test_page_path)).to_not eq nil
-        expect(CrowiClient.instance.page_id(path_exp: test_page_path_extend_for_get)).to_not eq nil
+        expect(crowi_client.page_id(path_exp: test_page_path)).to_not eq nil
+        expect(crowi_client.page_id(path_exp: test_page_path_extend_for_get)).to_not eq nil
       end
     end
   end


### PR DESCRIPTION
- 環境変数を使って CrowiClient を initialize できるよう修正
- initialize 時に環境変数を設定して複数の Crowi も扱えるよう CrowiClient の singleton パターンを止めた
- CrowiClient の使い方の変更を README に反映