### PR TITLE
Fix/methods to get or check existence return nil inspite of target exists

### DIFF
--- a/lib/crowi/client/client.rb
+++ b/lib/crowi/client/client.rb
@@ -40,8 +40,7 @@ class CrowiClient
   # @param [String] path ページパス
   # @return [true/false] ページの存在
   def page_exist?(path_exp: nil)
-    ret = request(CPApiRequestPagesList.new path_exp: path_exp)
-    return ret&.ok && ret&.data&.find { |p| p.path.match(path_exp) } != nil
+    return !page_id(path_exp: path_exp).nil?
   end
 
   # ページに添付ファイルが存在するか調べる

--- a/lib/crowi/client/version.rb
+++ b/lib/crowi/client/version.rb
@@ -1,5 +1,5 @@
 module Crowi
   module Client
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
- `CrowiClient::page_exist?` メソッドが URL エンコードの有無により、存在していても存在しないと判定してしまっていたため修正