### PR TITLE
Imprv/basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ require 'crowi-client'
 
 crowi_client = CrowiClient.new(crowi_url: ENV['CROWI_URL'], access_token: ENV['CROWI_ACCESS_TOKEN'])
 
-puts crowi_client.page_exist?( path_exp: '/' )
-puts crowi_client.attachment_exist?( path_exp: '/', attachment_name: 'LICENSE.txt' )
+p crowi_client.page_exist?( path_exp: '/' )
+p crowi_client.attachment_exist?( path_exp: '/', attachment_name: 'LICENSE.txt' )
 ```
 
 ## Examples
 
 ```ruby
 # get page's ID
-puts crowi_client.page_id( path_exp: '/' )
+p crowi_client.page_id( path_exp: '/' )
 ```
 
 ```ruby
@@ -57,30 +57,30 @@ crowi_client.attachment_exist?( path_exp: '/', attachment_name: 'LICENSE.txt' )
 
 ```ruby
 # get attachment's ID
-puts crowi_client.attachment_id( path_exp: '/', attachment_name: 'LICENSE.txt' )
+p crowi_client.attachment_id( path_exp: '/', attachment_name: 'LICENSE.txt' )
 ```
 
 ```ruby
 # get attachment (return data is object of CrowiAttachment)
-puts crowi_client.attachment( path_exp: '/', attachment_name: 'LICENSE.txt' )
+p crowi_client.attachment( path_exp: '/', attachment_name: 'LICENSE.txt' )
 ```
 
 ```ruby
 # pages list
 req = CPApiRequestPagesList.new path_exp: '/'
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
 # pages get - path_exp
 req = CPApiRequestPagesList.new path_exp: '/'
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
 # pages get - page_id
 req = CPApiRequestPagesGet.new page_id: crowi_client.page_id(path_exp: '/')
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
@@ -90,7 +90,7 @@ ret = crowi_client.request(reqtmp)
 path = ret.data[0].path
 revision_id = ret.data[0].revision._id
 req = CPApiRequestPagesGet.new path: path, revision_id: revision_id
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
@@ -99,7 +99,7 @@ test_page_path = '/tmp/crowi-client test page'
 body = "# crowi-client\n"
 req = CPApiRequestPagesCreate.new path: test_page_path,
         body: body
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
@@ -114,7 +114,7 @@ test_cases.each do |grant|
   body = body + grant.to_s
   req = CPApiRequestPagesUpdate.new page_id: page_id,
           body: body, grant: grant
-  puts crowi_client.request(req)
+  p crowi_client.request(req)
 end
 ```
 
@@ -122,7 +122,7 @@ end
 # pages seen
 page_id = crowi_client.page_id(path_exp: '/')
 req = CPApiRequestPagesSeen.new page_id: page_id
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
@@ -130,7 +130,7 @@ puts crowi_client.request(req)
 test_page_path = '/tmp/crowi-client test page'
 page_id = crowi_client.page_id(path_exp: test_page_path)
 req = CPApiRequestLikesAdd.new page_id: page_id
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
@@ -138,14 +138,14 @@ puts crowi_client.request(req)
 test_page_path = '/tmp/crowi-client test page'
 page_id = crowi_client.page_id(path_exp: test_page_path)
 req = CPApiRequestLikesRemove.new page_id: page_id
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
 # update post
 test_page_path = '/tmp/crowi-client test page'
 req = CPApiRequestPagesUpdatePost.new path: test_page_path
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 
@@ -154,7 +154,7 @@ puts crowi_client.request(req)
 test_page_path = '/tmp/crowi-client test page'
 page_id = crowi_client.page_id(path_exp: test_page_path)
 req = CPApiRequestAttachmentsList.new page_id: page_id
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
@@ -163,7 +163,7 @@ test_page_path = '/tmp/crowi-client test page'
 page_id = crowi_client.page_id(path_exp: test_page_path)
 req = CPApiRequestAttachmentsAdd.new page_id: page_id,
                                      file: File.new('LICENSE.txt')
-puts crowi_client.request(req)
+p crowi_client.request(req)
 ```
 
 ```ruby
@@ -174,7 +174,24 @@ reqtmp = CPApiRequestAttachmentsList.new page_id: page_id
 ret = crowi_client.request(reqtmp)
 attachment_id = ret.data[0]._id
 req = CPApiRequestAttachmentsRemove.new attachment_id: attachment_id
-puts crowi_client.request(req)
+p crowi_client.request(req)
+```
+
+### Basic Authentication
+
+```ruby
+require 'crowi-client'
+
+# Create crowiclient instance with username and password that is used by basic authentication
+crowi_client = CrowiClient.new(crowi_url: ENV['CROWI_URL'], access_token: ENV['CROWI_ACCESS_TOKEN'],
+                               rest_client_param: { user: 'who', password: 'bar'})
+
+# Check existence of page
+p crowi_client.page_exist?( path_exp: '/' ) ? '/ exist' : '/ not exist'
+
+# Create page whose path is '/tmp'
+req = CPApiRequestPagesCreate.new path: '/tmp', body: 'tmp'
+p crowi_client.request(req)
 ```
 
 ## Development
@@ -197,4 +214,4 @@ Everyone interacting in the Crowi::Client project’s codebases, issue trackers,
 
 ## ToDo
 
-- [ ] Support crowi with basic Authentication
+- [x] Support crowi with basic Authentication

--- a/lib/crowi/client/apireq/api_request_attachments.rb
+++ b/lib/crowi/client/apireq/api_request_attachments.rb
@@ -115,8 +115,10 @@ class CPApiRequestAttachmentsRemove < CPApiRequestBase
     if invalid?
       return validation_msg
     end
-    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge(rest_client_param)
+    params = { method: :post, url: entry_point,
+               payload: @param.to_json,
+               headers: { content_type: :json, accept: :json }
+             }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"

--- a/lib/crowi/client/apireq/api_request_attachments.rb
+++ b/lib/crowi/client/apireq/api_request_attachments.rb
@@ -116,7 +116,7 @@ class CPApiRequestAttachmentsRemove < CPApiRequestBase
       return validation_msg
     end
     params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge()
+               headers: { params: @param.to_json } }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"

--- a/lib/crowi/client/apireq/api_request_attachments.rb
+++ b/lib/crowi/client/apireq/api_request_attachments.rb
@@ -14,12 +14,14 @@ class CPApiRequestAttachmentsList < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.get entry_point, params: @param
+    params = { method: :get, url: entry_point, headers: { params: @param } }.merge(rest_client_param)
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -57,12 +59,13 @@ class CPApiRequestAttachmentsAdd < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [String] リクエスト実行結果（JSON形式）
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
     if invalid?
       return validation_msg
     end
-    req = RestClient::Request.new(
+    params = {
       method: :post,
       url:    entry_point,
       payload: {
@@ -70,8 +73,8 @@ class CPApiRequestAttachmentsAdd < CPApiRequestBase
         page_id:      @param[:page_id],
         file:         @param[:file]
       }
-    )
-    ret = JSON.parse req.execute
+    }.merge(rest_client_param)
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -103,17 +106,18 @@ class CPApiRequestAttachmentsRemove < CPApiRequestBase
           { attachment_id: param[:attachment_id] })
   end
 
-
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.post entry_point, @param.to_json,
-                          { content_type: :json, accept: :json }
+    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
+               headers: { params: @param.to_json } }.merge()
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end

--- a/lib/crowi/client/apireq/api_request_pages.rb
+++ b/lib/crowi/client/apireq/api_request_pages.rb
@@ -16,14 +16,16 @@ class CPApiRequestPagesList < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
+  # @param  [Hash] rest_client_param RestClientのパラメータ
   # @return [Array] リクエスト実行結果
-  def execute(entry_point)
+  def execute(entry_point, rest_client_param: {})
 
     if invalid?
       return validation_msg
     end
 
-    ret = JSON.parse RestClient.get entry_point, params: @param
+    param = { method: :get, url: entry_point, headers: { params: @param } }.merge(rest_client_param)
+    ret = JSON.parse RestClient::Request.execute param
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -41,7 +43,10 @@ protected
   # @return [nil/CPInvalidRequest] バリデーションエラー結果
   def _invalid
     if ! (@param[:path] || @param[:user])
-      return CPInvalidRequest.new 'Parameter path or page_id is required.'
+      return CPInvalidRequest.new 'Parameter path or user is required.'
+    end
+    if (@param[:path] && @param[:user])
+      return CPInvalidRequest.new 'Parameter path and user can not be specified both.'
     end
   end
 

--- a/lib/crowi/client/apireq/api_request_pages.rb
+++ b/lib/crowi/client/apireq/api_request_pages.rb
@@ -121,8 +121,10 @@ class CPApiRequestPagesCreate < CPApiRequestBase
       return validation_msg
     end
 
-    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge(rest_client_param)
+    params = { method: :post, url: entry_point,
+               payload: @param.to_json,
+               headers: { content_type: :json, accept: :json }
+             }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
@@ -166,8 +168,10 @@ class CPApiRequestPagesUpdate < CPApiRequestBase
     if invalid?
       return validation_msg
     end
-    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge(rest_client_param)
+    params = { method: :post, url: entry_point,
+               payload: @param.to_json,
+               headers: { content_type: :json, accept: :json }
+             }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
@@ -210,8 +214,10 @@ class CPApiRequestPagesSeen < CPApiRequestBase
     if invalid?
       return validation_msg
     end
-    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge(rest_client_param)
+    params = { method: :post, url: entry_point,
+               payload: @param.to_json,
+               headers: { content_type: :json, accept: :json }
+             }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
@@ -253,8 +259,10 @@ class CPApiRequestLikesAdd < CPApiRequestBase
     if invalid?
       return validation_msg
     end
-    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge(rest_client_param)
+    params = { method: :post, url: entry_point,
+               payload: @param.to_json,
+               headers: { content_type: :json, accept: :json }
+             }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
@@ -296,8 +304,10 @@ class CPApiRequestLikesRemove < CPApiRequestBase
     if invalid?
       return validation_msg
     end
-    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge(rest_client_param)
+    params = { method: :post, url: entry_point,
+               payload: @param.to_json,
+               headers: { content_type: :json, accept: :json }
+             }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"

--- a/lib/crowi/client/apireq/api_request_pages.rb
+++ b/lib/crowi/client/apireq/api_request_pages.rb
@@ -24,8 +24,8 @@ class CPApiRequestPagesList < CPApiRequestBase
       return validation_msg
     end
 
-    param = { method: :get, url: entry_point, headers: { params: @param } }.merge(rest_client_param)
-    ret = JSON.parse RestClient::Request.execute param
+    params = { method: :get, url: entry_point, headers: { params: @param } }.merge(rest_client_param)
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -69,13 +69,15 @@ class CPApiRequestPagesGet < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
 
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.get entry_point, params: @param
+    params = { method: :get, url: entry_point, headers: { params: @param } }.merge(rest_client_param)
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -111,14 +113,17 @@ class CPApiRequestPagesCreate < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
 
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.post entry_point, @param.to_json,
-                          { content_type: :json, accept: :json }
+
+    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
+               headers: { params: @param.to_json } }.merge()
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -154,14 +159,16 @@ class CPApiRequestPagesUpdate < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
 
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.post entry_point, @param.to_json,
-                          { content_type: :json, accept: :json }
+    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
+               headers: { params: @param.to_json } }.merge()
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -196,14 +203,16 @@ class CPApiRequestPagesSeen < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
 
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.post entry_point, @param.to_json,
-                          { content_type: :json, accept: :json }
+    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
+               headers: { params: @param.to_json } }.merge()
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -237,14 +246,16 @@ class CPApiRequestLikesAdd < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
 
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.post entry_point, @param.to_json,
-                          { content_type: :json, accept: :json }
+    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
+               headers: { params: @param.to_json } }.merge()
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -278,14 +289,16 @@ class CPApiRequestLikesRemove < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
 
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.post entry_point, @param.to_json,
-                          { content_type: :json, accept: :json }
+    params = { method: :post, url: entry_point, content_type: :json, accept: :json,
+               headers: { params: @param.to_json } }.merge()
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -320,13 +333,15 @@ class CPApiRequestPagesUpdatePost < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
 
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.get entry_point, params: @param
+    params = { method: :get, url: entry_point, headers: { params: @param } }.merge(rest_client_param)
+    ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end
@@ -366,13 +381,15 @@ class CPApiRequestPagesRemove < CPApiRequestBase
   # リクエストを実行する
   # @override
   # @param  [String] entry_point APIのエントリーポイントとなるURL（ex. http://localhost:3000/_api/pages.list）
-  # @return [CrowiPage] リクエスト実行結果
-  def execute(entry_point)
+  # @param  [Hash] rest_client_param RestClientのパラメータ
+  # @return [Array] リクエスト実行結果
+  def execute(entry_point, rest_client_param: {})
 
     if invalid?
       return validation_msg
     end
-    ret = JSON.parse RestClient.get entry_point, params: @param
+    param = { method: :get, url: entry_point, headers: { params: @param } }.merge(rest_client_param)
+    ret = JSON.parse RestClient::Request.execute param
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
     end

--- a/lib/crowi/client/apireq/api_request_pages.rb
+++ b/lib/crowi/client/apireq/api_request_pages.rb
@@ -122,7 +122,7 @@ class CPApiRequestPagesCreate < CPApiRequestBase
     end
 
     params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge()
+               headers: { params: @param.to_json } }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
@@ -167,7 +167,7 @@ class CPApiRequestPagesUpdate < CPApiRequestBase
       return validation_msg
     end
     params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge()
+               headers: { params: @param.to_json } }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
@@ -211,7 +211,7 @@ class CPApiRequestPagesSeen < CPApiRequestBase
       return validation_msg
     end
     params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge()
+               headers: { params: @param.to_json } }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
@@ -254,7 +254,7 @@ class CPApiRequestLikesAdd < CPApiRequestBase
       return validation_msg
     end
     params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge()
+               headers: { params: @param.to_json } }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"
@@ -297,7 +297,7 @@ class CPApiRequestLikesRemove < CPApiRequestBase
       return validation_msg
     end
     params = { method: :post, url: entry_point, content_type: :json, accept: :json,
-               headers: { params: @param.to_json } }.merge()
+               headers: { params: @param.to_json } }.merge(rest_client_param)
     ret = JSON.parse RestClient::Request.execute params
     if (ret['ok'] == false)
       return CPInvalidRequest.new "API return false with msg: #{ret['msg']}"

--- a/lib/crowi/client/client.rb
+++ b/lib/crowi/client/client.rb
@@ -10,12 +10,13 @@ require 'crowi/client/apireq/api_request_attachments'
 class CrowiClient
 
   # コンストラクタ
-  def initialize(crowi_url: '', access_token: '')
+  def initialize(crowi_url: '', access_token: '', rest_client_param: {})
     raise ArgumentError, 'Config `crowi_url` is required.'    if crowi_url.empty?
     raise ArgumentError, 'Config `access_token` is required.' if access_token.empty?
 
     @crowi_url = crowi_url
-    @access_toke = access_token
+    @access_token = access_token
+    @rest_client_param = rest_client_param
     @cp_entry_point = URI.join(crowi_url, '/_api/').to_s
   end
 
@@ -23,8 +24,9 @@ class CrowiClient
   # @param [ApiRequestBase] req APIリクエスト
   # @return [String] APIリクエストの応答（JSON形式）
   def request(req)
-    req.param[:access_token] = @access_toke
-    return req.execute URI.join(@cp_entry_point, req.entry_point).to_s
+    req.param[:access_token] = @access_token
+    return req.execute URI.join(@cp_entry_point, req.entry_point).to_s,
+                       rest_client_param: @rest_client_param
   end
 
   # ページIDを取得する
@@ -56,17 +58,16 @@ class CrowiClient
   # @param  [String] path_exp ページパス（正規表現）
   # @return [String] attachment's file name
   def attachment_id(path_exp: nil, attachment_name: nil)
-      ret = request(CPApiRequestAttachmentsList.new page_id: page_id(path_exp: path_exp))
-      return ret&.data&.find { |a| a.originalName == attachment_name }&._id
+    ret = request(CPApiRequestAttachmentsList.new page_id: page_id(path_exp: path_exp))
+    return ret&.data&.find { |a| a.originalName == attachment_name }&._id
   end
 
   # 指定した添付ファイル情報を取得する
   # @param  [String] path_exp ページパス（正規表現）
   # @return [String] attachment's file name
   def attachment(path_exp: nil, attachment_name: nil)
-      ret = request(CPApiRequestAttachmentsList.new page_id: page_id(path_exp: path_exp))
-      return ret&.data&.find { |a| a.originalName == attachment_name }
+    ret = request(CPApiRequestAttachmentsList.new page_id: page_id(path_exp: path_exp))
+    return ret&.data&.find { |a| a.originalName == attachment_name }
   end
 
 end
-

--- a/lib/crowi/client/version.rb
+++ b/lib/crowi/client/version.rb
@@ -1,5 +1,5 @@
 module Crowi
   module Client
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end


### PR DESCRIPTION
Basic Authentication が設定されている Crowi への API 操作が出来るよう、
API リクエスト実行時に rest_client_param オプションを追加。
rest_client_param に username, password を設定すれば Basic Authentication が行える。
それ以外も RestClient が対応していればパラメータとして設定可能。